### PR TITLE
Add precision/recall metrics

### DIFF
--- a/ensemble.py
+++ b/ensemble.py
@@ -27,7 +27,7 @@ def main():
     outputs = maximum([y1, y2])
     ensemble_model = Model(inputs=inputs, outputs=outputs)
     ensemble_model.compile(
-        optimizer='sgd', loss='categorical_crossentropy', metrics=['accuracy'])
+        optimizer='sgd', loss='categorical_crossentropy', metrics=lib.METRICS)
 
     lib.testModel(ensemble_model, 64, dataset, num_classes,
                   model_name, image_size, preprocess_input, output_statistics)

--- a/lib.py
+++ b/lib.py
@@ -10,6 +10,9 @@ import pandas as pd
 import matplotlib
 matplotlib.use('pdf')
 
+METRICS = ['accuracy',
+      tf.keras.metrics.Precision(name='precision'),
+      tf.keras.metrics.Recall(name='recall')]
 
 def createModel(baseModel, hidden_layers, num_classes):
     model = Sequential()
@@ -28,7 +31,7 @@ def createModel(baseModel, hidden_layers, num_classes):
 
     # Compile the sections into one NN
     model.compile(optimizer='sgd', loss='categorical_crossentropy',
-                  metrics=['accuracy'])
+                  metrics=METRICS)
     return model
 
 
@@ -63,10 +66,14 @@ def trainModel(datasetPath, model, epochs, batch_size, image_size, preprocess_in
 def create_pdf(history, model_name):
     print("Generating pdf for " + model_name)
 
-    df = pd.DataFrame(history.history)
+    # grab the desired metrics from tf history
+    desired_metrics = ['accuracy', 'loss', 'val_accuracy', 'val_loss']
+    metrics_to_plot = dict((k, history.history[k]) for k in desired_metrics if k in history.history)
+
+    df = pd.DataFrame(metrics_to_plot)
     df.index = range(1, len(df)+1)
     df.rename(columns={'accuracy': 'Training Accuracy', 'loss': 'Training Loss',
-                       'val_accuracy': 'Validation Accuracy', 'val_loss': 'Validation Loss'}, inplace=True)
+        'val_accuracy': 'Validation Accuracy', 'val_loss': 'Validation Loss'}, inplace=True)
     print(df)
     sns.set()
     ax = sns.lineplot(hue='event', marker='o', dashes=False, data=df)

--- a/simple-neural-net.py
+++ b/simple-neural-net.py
@@ -13,7 +13,6 @@ image_size = 224
 num_classes = 2
 epochs = 5
 
-
 def main():
     fire_detector_model = Sequential([
         Flatten(),
@@ -24,7 +23,7 @@ def main():
 
     fire_detector_model.compile(optimizer='rmsprop',
                                 loss='categorical_crossentropy',
-                                metrics=['accuracy'])
+                                metrics=lib.METRICS)
 
     history = lib.trainModel(dataset, fire_detector_model,
                              epochs, batch_size, image_size, preprocess_input)


### PR DESCRIPTION
Add precision and recall metrics to the metrics variable during model.compile -- we can use these values in our report. 

Updated Matt's plot function to only select the accuracy/loss metrics as desired. 